### PR TITLE
Fixed error that filled the buffer

### DIFF
--- a/http/lib.c
+++ b/http/lib.c
@@ -64,10 +64,10 @@ void initPeripherals(long* c)
 	
     init_LEDs();
 
-    init_bme280();
-    init_mpu6050();
-    init_bh1750();
-    init_acoustic();
+    init_bme280(true);
+    init_mpu6050(true);
+    init_bh1750(true);
+    init_acoustic(true);
 }
 
 
@@ -97,10 +97,10 @@ void connectNetwork(struct device *z)
 
 void pnp_sensors()
 {
-    init_bme280();
-    init_mpu6050();	
-    init_bh1750();	
-    init_acoustic();
+    init_bme280(false);
+    init_mpu6050(false);	
+    init_bh1750(false);	
+    init_acoustic(false);
 }
 
 

--- a/http/raspi3-4/acoustic/acoustic.c
+++ b/http/raspi3-4/acoustic/acoustic.c
@@ -21,12 +21,15 @@ bool check_acoustic()
 	return false;
 }
 
-void init_acoustic()
+void init_acoustic(bool ft)
 {
-    pullUpDnControl(ACOUSTIC_ENABLE, PUD_UP);
-    pinMode (ACOUSTIC_ENABLE, INPUT);
+	if (ft)
+	{
+		pullUpDnControl(ACOUSTIC_ENABLE, PUD_UP);
+		pinMode (ACOUSTIC_ENABLE, INPUT);
     
-    pinMode (ACOUSTIC_DATA, INPUT);
+		pinMode (ACOUSTIC_DATA, INPUT);
+	}
 }
 
 void print_acoustic()

--- a/http/raspi3-4/acoustic/acoustic.h
+++ b/http/raspi3-4/acoustic/acoustic.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-void init_acoustic(void);
+void init_acoustic(bool);
 bool check_acoustic(void);
 char* get_acoustic(void);
 void print_acoustic(void);

--- a/http/raspi3-4/bh1750/bh1750.c
+++ b/http/raspi3-4/bh1750/bh1750.c
@@ -22,9 +22,10 @@ bool check_bh1750()
     	return true;
 }
 
-void init_bh1750()
+void init_bh1750(bool ft)
 {
-    fd_bh = wiringPiI2CSetup(0x23);
+	if (ft)
+		fd_bh = wiringPiI2CSetup(0x23);
 } 
 
 void print_bh1750()

--- a/http/raspi3-4/bh1750/bh1750.h
+++ b/http/raspi3-4/bh1750/bh1750.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 bool check_bh1750(void);
-void init_bh1750(void);
+void init_bh1750(bool);
 char* get_bh1750(void);
 void print_bh1750(void);
 

--- a/http/raspi3-4/bme280/bme280.c
+++ b/http/raspi3-4/bme280/bme280.c
@@ -26,9 +26,10 @@ bool check_bme280()
 	return true;
 }
 
-void init_bme280()
-{
-    fd_bme = wiringPiI2CSetup(0x76);
+void init_bme280(bool ft)
+{   
+	if (ft)
+		fd_bme = wiringPiI2CSetup(0x76);
 
     readCalibrationData(fd_bme, &cal);
 

--- a/http/raspi3-4/bme280/bme280.h
+++ b/http/raspi3-4/bme280/bme280.h
@@ -88,7 +88,7 @@ typedef struct
 
 } bme280_raw_data;
 
-void init_bme280(void);
+void init_bme280(bool);
 bool check_bme280(void);
 char* get_bme280(int ind);
 void print_bme280(void);

--- a/http/raspi3-4/mpu6050/mpu6050.c
+++ b/http/raspi3-4/mpu6050/mpu6050.c
@@ -19,9 +19,11 @@ bool check_mpu6050()
     	return true;
 }
 
-void init_mpu6050()
+void init_mpu6050(bool ft)
 {
-    fd_mpu = wiringPiI2CSetup(Device_Address);   /*Initializes I2C with device Address*/
+	if (ft)
+		fd_mpu = wiringPiI2CSetup(Device_Address);   /*Initializes I2C with device Address*/
+    
     wiringPiI2CWriteReg8 (fd_mpu, SMPLRT_DIV, 0x07);	/* Write to sample rate register */
     wiringPiI2CWriteReg8 (fd_mpu, PWR_MGMT_1, 0x01);	/* Write to power management register */
     wiringPiI2CWriteReg8 (fd_mpu, CONFIG, 0);		/* Write to Configuration register */

--- a/http/raspi3-4/mpu6050/mpu6050.h
+++ b/http/raspi3-4/mpu6050/mpu6050.h
@@ -20,7 +20,7 @@
 
 bool check_mpu6050(void);
 short read_raw_data(int);
-void init_mpu6050(void);
+void init_mpu6050(bool);
 void print_mpu6050(void);
 char* get_mpu6050(int);
 


### PR DESCRIPTION
Fixed error that filled the buffer, due to repeated sensors initializations during runtime.